### PR TITLE
[kube-prometheus-stack] Add option to exclude node time rules

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml
@@ -202,6 +202,7 @@ spec:
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
 {{- end }}
+{{- if .Values.defaultRules.rules.time }}
     - alert: NodeClockSkewDetected
       annotations:
         message: Clock on {{`{{`}} $labels.instance {{`}}`}} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.
@@ -237,6 +238,7 @@ spec:
         severity: warning
 {{- if .Values.defaultRules.additionalRuleLabels }}
 {{ toYaml .Values.defaultRules.additionalRuleLabels | indent 8 }}
+{{- end }}
 {{- end }}
     - alert: NodeRAIDDegraded
       annotations:


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows a user to exclude the node time rules.

#### Which issue this PR fixes
  - fixes #882

#### Special notes for your reviewer:
First PR for me, please let me know if I need to add anything else.

I'm not sure whether to split out the time related rules into a `node-time.rules` as done for the rules for Kubernetes versions below 1.14.

#### Checklist
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
